### PR TITLE
Latency alert and recording rule

### DIFF
--- a/monitor/rules/alerts.yml
+++ b/monitor/rules/alerts.yml
@@ -7,3 +7,115 @@ groups:
     annotations:
       description: A dependência {{$labels.name}} do serviço {{$labels.prsn}} não está respondendo.
       summary: Alerta para caso uma dependência passe mais de 2 minutos sem resposta
+
+- name: suddenly_high_latency
+  rules:
+  - record: request_seconds_latency
+    expr:
+      sum by (addr, prsn, method, status, type) (request_seconds_sum:irate)
+      /
+      sum by (addr, prsn, method, status, type) (request_seconds_count:irate)
+
+  - record: request_seconds_latency:avg_max
+    expr:
+      avg_over_time(
+        max_over_time(
+          avg_over_time(
+            (sum by (addr, prsn, method, status, type) (request_seconds_sum:irate)
+            /
+            sum by (addr, prsn, method, status, type) (request_seconds_count:irate))
+          [1m:])
+        [20m:])
+      [1h:])
+
+
+  - alert: request_seconds_count_latency_increase_10_percent
+    expr:
+      (
+        ( requests_seconds_latency * 100)
+        /
+        ( request_seconds_latency:avg_max * 100)
+      ) >= 1.1
+    for: 5m
+    labels:
+      severity: minor
+      type_signal: latency
+    annotations:
+      description: O recurso no endereço {{$labels.addr}} do serviço {{$labels.prsn}} está com um aumento da latência em 10%.
+      summary: Alerta para as requisições que, com base na média dos máximos histórico de uma hora, tenha um aumento no tempo de resposta em 10% por mais de cinco minutos.
+
+  - alert: request_seconds_count_latency_increase_10_percent
+    expr:
+      (
+        ( requests_seconds_latency * 100)
+        /
+        ( request_seconds_latency:avg_max * 100)
+      ) >= 1.1
+    for: 5m
+    labels:
+      severity: warning
+      type_signal: latency
+    annotations:
+      description: O recurso no endereço {{$labels.addr}} do serviço {{$labels.prsn}} está com um aumento da latência em 10%.
+      summary: Alerta para as requisições que, com base na média dos máximos histórico de uma hora, tenha um aumento no tempo de resposta em 10% por mais de cinco minutos.
+
+  - alert: request_seconds_count_latency_increase_20_percent
+    expr:
+      (
+        ( requests_seconds_latency * 100)
+        /
+        ( request_seconds_latency:avg_max * 100)
+      ) >= 1.2
+    for: 5m
+    labels:
+      severity: minor
+      type_signal: latency
+    annotations:
+      description: O recurso no endereço {{$labels.addr}} do serviço {{$labels.prsn}} está com um aumento da latência em 20%.
+      summary: Alerta para as requisições que, com base na média dos máximos histórico de uma hora, tenha um aumento no tempo de resposta em 20% por mais de cinco minutos.
+
+  - alert: request_seconds_count_latency_increase_50_percent
+    expr:
+      (
+        ( requests_seconds_latency * 100)
+        /
+        ( request_seconds_latency:avg_max * 100)
+      ) >= 1.5
+    for: 5m
+    labels:
+      severity: normal
+      type_signal: latency
+    annotations:
+      description: O recurso no endereço {{$labels.addr}} do serviço {{$labels.prsn}} está com um aumento da latência em 50%.
+      summary: Alerta para as requisições que, com base na média dos máximos histórico de uma hora, tenha um aumento no tempo de resposta em 50% por mais de cinco minutos.
+
+  - alert: request_seconds_count_latency_increase_90_percent
+    expr:
+      (
+        ( requests_seconds_latency * 100)
+        /
+        ( request_seconds_latency:avg_max * 100)
+      ) >= 1.9
+    for: 5m
+    labels:
+      severity: major
+      type_signal: latency
+    annotations:
+      description: O recurso no endereço {{$labels.addr}} do serviço {{$labels.prsn}} está com um aumento da latência em 90%.
+      summary: Alerta para as requisições que, com base na média dos máximos histórico de uma hora, tenha um aumento no tempo de resposta em 90% por mais de cinco minutos.
+
+  - alert: request_seconds_count_latency_increase_100_percent
+    expr:
+      (
+        ( requests_seconds_latency * 100)
+        /
+        ( request_seconds_latency:avg_max * 100)
+      ) >= 2.0
+    for: 5m
+    labels:
+      severity: critical
+      type_signal: latency
+    annotations:
+      description: O recurso no endereço {{$labels.addr}} do serviço {{$labels.prsn}} está com um aumento da latência em 100%.
+      summary: Alerta para as requisições que, com base na média dos máximos histórico de uma hora, tenha um aumento no tempo de resposta em 100% por mais de cinco minutos.
+


### PR DESCRIPTION
For easy understanding, two **record** rules were created

Both were constructed using the same metrics, instead of the avg_max
using the first record rule. This guarantees the data used on the
algebraic formula is making reference to the same period of the time
series.

The **alert** rules created have to be multiplied by 100. Dividing two
decimal numbers smaller than one produces unwanted behaviour. If the
current value is greater than the historical data, it should alert based
on criticality.

110% -> warning
120% -> minor
150% -> normal
190% -> major
200% -> critical

As an example, here is two Grafana panels showing the rules created.

![Screenshot_2019-10-28 Google's Golden Rules - Grafana](https://user-images.githubusercontent.com/2037375/67724096-bbb6d480-f9bc-11e9-9142-943ad28b019c.png)


![Screenshot_2019-10-28 Google's Golden Rules - Grafana(1)](https://user-images.githubusercontent.com/2037375/67724100-c07b8880-f9bc-11e9-9b0f-f736f866f1f3.png)
